### PR TITLE
Fix Lombok version in pom and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 <details>
 <summary>Hướng dẫn dành cho dev</summary>
-Các loại thư viện đã được cài đặt sẵn: Springboot Web, Lombook, Spring JPA, Spring Security, Swagger OpenAPI.
+Các loại thư viện đã được cài đặt sẵn: Springboot Web, Lombok, Spring JPA, Spring Security, Swagger OpenAPI.
 Clone về là sử dụng bình thường.
 </details>

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,10 @@
 		<tag/>
 		<url/>
 	</scm>
-	<properties>
-		<java.version>21</java.version>
-	</properties>
+        <properties>
+                <java.version>21</java.version>
+                <lombok.version>1.18.32</lombok.version>
+        </properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -54,11 +55,12 @@
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
+                <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <version>${lombok.version}</version>
+                        <optional>true</optional>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -77,13 +79,14 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<annotationProcessorPaths>
-						<path>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</path>
-					</annotationProcessorPaths>
-				</configuration>
+                                        <annotationProcessorPaths>
+                                                <path>
+                                                        <groupId>org.projectlombok</groupId>
+                                                        <artifactId>lombok</artifactId>
+                                                        <version>${lombok.version}</version>
+                                                </path>
+                                        </annotationProcessorPaths>
+                                </configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- add Lombok version property
- use Lombok version for dependency and annotation processor
- fix README typo

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9c96801083218ccc0062f8b440f6