### PR TITLE
Adds Swagger/OpenAPI 3.0 configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.8</version>
+		</dependency>
+
+
+		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>

--- a/src/main/java/com/medischool/backend/config/OpenApiConfig.java
+++ b/src/main/java/com/medischool/backend/config/OpenApiConfig.java
@@ -1,0 +1,47 @@
+package com.medischool.backend.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+    private static final String BEARER_AUTH = "bearerAuth";
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .servers(List.of(
+                        new Server().url("/").description("Default Server URL")
+                ))
+                .info(new Info()
+                        .title("MediSchool API")
+                        .version("1.0")
+                        .description("API documentation for MediSchool application"))
+                .addSecurityItem(new SecurityRequirement().addList(BEARER_AUTH))
+                .components(new Components()
+                        .addSecuritySchemes(BEARER_AUTH,
+                                new SecurityScheme()
+                                        .name(BEARER_AUTH)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
+    }
+
+    @Bean
+    public GroupedOpenApi publicApi() {
+        return GroupedOpenApi.builder()
+                .group("public")
+                .pathsToMatch("/api/**")
+                .build();
+    }
+}

--- a/src/main/java/com/medischool/backend/config/SecurityConfig.java
+++ b/src/main/java/com/medischool/backend/config/SecurityConfig.java
@@ -24,6 +24,19 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .addFilterBefore(new JwtAuthenticationFilter(jwtSecret), UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
+                        // Allow Swagger UI and API docs
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs",
+                                "/v3/api-docs/swagger-config",
+                                "/webjars/**",
+                                "/swagger-resources/**",
+                                "/swagger-ui/index.html"
+                        ).permitAll()
+                        // Existing security rules
+                        .requestMatchers("/context-path/**").permitAll()
                         .requestMatchers("/api/me").authenticated()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/manager/**").hasRole("MANAGER")

--- a/src/main/java/com/medischool/backend/controller/MeController.java
+++ b/src/main/java/com/medischool/backend/controller/MeController.java
@@ -2,6 +2,7 @@ package com.medischool.backend.controller;
 
 import com.medischool.backend.model.UserProfile;
 import com.medischool.backend.repository.UserProfileRepository;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -14,6 +15,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping("/api")
+@Tag(name = "Personal Controller")
 public class MeController {
 
     @Autowired

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,13 @@ spring.application.name=backend
 spring.datasource.url=jdbc:postgresql://aws-0-ap-southeast-1.pooler.supabase.com:6543/postgres?user=postgres.zmuagvzgbfriotrrdjrg&password=12345
 
 supabase.jwt.secret=xSoEX9Ih7Tuy9LrI72csoJKfjI368Fr7HBeCFg6kGCSjRove+vmy+y7jHJlWaahYejfoehtyP1CKx6RaVTJarQ==
+
+# Swagger/OpenAPI Configuration
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.operationsSorter=method
+springdoc.swagger-ui.tagsSorter=alpha
+springdoc.swagger-ui.tryItOutEnabled=true
+springdoc.swagger-ui.filter=true
+springdoc.swagger-ui.syntaxHighlight.activated=true
+springdoc.swagger-ui.syntaxHighlight.theme=monokai


### PR DESCRIPTION
Implements Swagger/OpenAPI 3.0 configuration for API documentation and exploration:

- Enables Swagger UI for interactive API documentation.
- Configures security scheme for JWT Bearer authentication.
- Defines API information and server details.
- Exposes API documentation under `/v3/api-docs`.
- Adds configuration properties for customizing Swagger UI.