### PR TITLE
Exposes detailed vaccine consent information

### DIFF
--- a/src/main/java/com/medischool/backend/controller/VaccineConsentController.java
+++ b/src/main/java/com/medischool/backend/controller/VaccineConsentController.java
@@ -1,5 +1,6 @@
 package com.medischool.backend.controller;
 
+import com.medischool.backend.dto.vaccine.VaccineConsentDTO;
 import com.medischool.backend.dto.vaccine.VaccineConsentInEvent;
 import com.medischool.backend.model.enums.ConsentStatus;
 import com.medischool.backend.model.vaccine.VaccinationConsent;
@@ -8,6 +9,7 @@ import com.medischool.backend.service.VaccineConsentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -71,5 +73,18 @@ public class VaccineConsentController {
     @Operation(summary = "Get all vaccine consents of a specific vaccine event")
     public ResponseEntity<List<VaccineConsentInEvent>> getVaccinationConsentsByEventId(@PathVariable("eventId") Long eventId) {
         return ResponseEntity.ok(vaccinationConsentService.getVaccinationConsentsByEventId(eventId));
+    }
+
+    @GetMapping("/{consentId}")
+    @Operation(summary = "Get detailed consent")
+    public ResponseEntity<?> getVaccineConsent(@PathVariable Long consentId) {
+        try {
+            VaccineConsentDTO dto = vaccinationConsentService.getVaccineConsent(consentId);
+            return ResponseEntity.ok(dto);
+        } catch (RuntimeException e) {
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", e.getMessage()));
+        }
     }
 }

--- a/src/main/java/com/medischool/backend/dto/vaccine/VaccineConsentDTO.java
+++ b/src/main/java/com/medischool/backend/dto/vaccine/VaccineConsentDTO.java
@@ -1,0 +1,27 @@
+package com.medischool.backend.dto.vaccine;
+
+import com.medischool.backend.model.UserProfile;
+import com.medischool.backend.model.enums.ConsentStatus;
+import com.medischool.backend.model.parentstudent.Student;
+import com.medischool.backend.model.vaccine.VaccineEvent;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VaccineConsentDTO {
+    private Long id;
+    private VaccineEvent event;
+    private UserProfile parent;
+    private Student student;
+    private String note;
+    private LocalDateTime createdAt;
+    private ConsentStatus  consentStatus;
+}

--- a/src/main/java/com/medischool/backend/model/vaccine/VaccinationConsent.java
+++ b/src/main/java/com/medischool/backend/model/vaccine/VaccinationConsent.java
@@ -17,7 +17,6 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-//@EntityListeners(VaccinationConsentListener.class)
 public class VaccinationConsent {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/medischool/backend/service/VaccinationConsentService.java
+++ b/src/main/java/com/medischool/backend/service/VaccinationConsentService.java
@@ -1,5 +1,6 @@
 package com.medischool.backend.service;
 
+import com.medischool.backend.dto.vaccine.VaccineConsentDTO;
 import com.medischool.backend.dto.vaccine.VaccineConsentInEvent;
 
 import java.util.List;
@@ -9,4 +10,5 @@ public interface VaccinationConsentService {
     Long getTotalConsents();
     List<VaccineConsentInEvent> getVaccinationConsentsByEventId(Long eventId);
     Map <String, Object> getConsentResult();
+    VaccineConsentDTO getVaccineConsent(Long consentId);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@ supabase.jwt.secret=xSoEX9Ih7Tuy9LrI72csoJKfjI368Fr7HBeCFg6kGCSjRove+vmy+y7jHJlW
 
 supabase.url=https://zmuagvzgbfriotrrdjrg.supabase.co
 supabase.api.key=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InptdWFndnpnYmZyaW90cnJkanJnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg2NTU5ODIsImV4cCI6MjA2NDIzMTk4Mn0.hRgQGxu-8S3FxRwPP8JeElFs14JQS8AAL2lTFi6T0JQ
-app.jwt.expiration.minutes=30
+app.jwt.expiration.minutes=10
 
 # Swagger/OpenAPI Configuration
 springdoc.api-docs.path=/v3/api-docs


### PR DESCRIPTION
Adds an endpoint to retrieve detailed information about a specific vaccine consent, including associated event, parent, and student details.
Creates a DTO to encapsulate the data required for the response.
Handles cases where consent, event, parent, or student records are not found, returning a 404 error.
